### PR TITLE
Remove Titan AA missile from Spike

### DIFF
--- a/Addons/itc_land_spike/config/CfgWeapons.hpp
+++ b/Addons/itc_land_spike/config/CfgWeapons.hpp
@@ -15,7 +15,7 @@ class CfgWeapons {
     picture = "\A3\Weapons_F_Enoch\Launchers\Titan\Data\UI\icon_launch_B_Titan_olive_F_ca.paa";
     hiddenSelectionsTextures[] = {"\a3\weapons_f_beta\launchers\titan\data\launcher_indp_co.paa","\A3\Weapons_F_Enoch\Launchers\Titan\Data\launch_B_Titan_olive_F_02_co.paa"};    
     magazines[] = {"itc_land_spikeLR_1rnd"};
-	  magazineWell[] = {};
+    magazineWell[] = {};
     class EventHandlers {
         class itc_land_spike {
             fired = "_this call itc_land_spike_fnc_fired;";

--- a/Addons/itc_land_spike/config/CfgWeapons.hpp
+++ b/Addons/itc_land_spike/config/CfgWeapons.hpp
@@ -15,7 +15,7 @@ class CfgWeapons {
     picture = "\A3\Weapons_F_Enoch\Launchers\Titan\Data\UI\icon_launch_B_Titan_olive_F_ca.paa";
     hiddenSelectionsTextures[] = {"\a3\weapons_f_beta\launchers\titan\data\launcher_indp_co.paa","\A3\Weapons_F_Enoch\Launchers\Titan\Data\launch_B_Titan_olive_F_02_co.paa"};    
     magazines[] = {"itc_land_spikeLR_1rnd"};
-	magazineWell[] = {};
+	  magazineWell[] = {};
     class EventHandlers {
         class itc_land_spike {
             fired = "_this call itc_land_spike_fnc_fired;";

--- a/Addons/itc_land_spike/config/CfgWeapons.hpp
+++ b/Addons/itc_land_spike/config/CfgWeapons.hpp
@@ -15,6 +15,7 @@ class CfgWeapons {
     picture = "\A3\Weapons_F_Enoch\Launchers\Titan\Data\UI\icon_launch_B_Titan_olive_F_ca.paa";
     hiddenSelectionsTextures[] = {"\a3\weapons_f_beta\launchers\titan\data\launcher_indp_co.paa","\A3\Weapons_F_Enoch\Launchers\Titan\Data\launch_B_Titan_olive_F_02_co.paa"};    
     magazines[] = {"itc_land_spikeLR_1rnd"};
+	magazineWell[] = {};
     class EventHandlers {
         class itc_land_spike {
             fired = "_this call itc_land_spike_fnc_fired;";


### PR DESCRIPTION
The Spike still inherited the Titan's magazineWell, which contained the Titan AA missile.